### PR TITLE
CI on master and pull requests, and a guard for documentation rot

### DIFF
--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>recon — API documentation</title>
+<style>
+  :root {
+    --bg: #ffffff; --fg: #1b1b1b; --muted: #5a5a5a; --rule: #e3e3e3; --link: #0b5cad;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg: #14161a; --fg: #e6e6e6; --muted: #a2a8b0; --rule: #2b2f36; --link: #7fb2f0; }
+  }
+  * { box-sizing: border-box; }
+  body {
+    background: var(--bg); color: var(--fg); margin: 0 auto; padding: 3rem 1.25rem 5rem;
+    max-width: 44rem; line-height: 1.55;
+    font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  h1 { font-size: 1.6rem; margin: 0 0 .25rem; }
+  .sub { color: var(--muted); margin: 0 0 2.5rem; }
+  a { color: var(--link); }
+  ul { list-style: none; padding: 0; margin: 0; }
+  li { border-top: 1px solid var(--rule); padding: 1.1rem 0; }
+  li:last-child { border-bottom: 1px solid var(--rule); }
+  .name { font-weight: 600; font-size: 1.05rem; }
+  .name code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  .what { color: var(--muted); margin: .3rem 0 0; }
+  footer { color: var(--muted); margin-top: 3rem; font-size: .9rem; }
+</style>
+
+<h1>recon</h1>
+<p class="sub">Distributed message-passing algorithms, written so the code reads as the algorithm.</p>
+
+<p>
+  Three crates, all of them sans-IO: no protocol here opens a socket, reads a clock or reaches for
+  randomness. They are listed in the order they depend on each other, which is also the order they
+  are worth reading in.
+</p>
+
+<ul>
+  <li>
+    <div class="name"><a href="recon_core/index.html"><code>recon_core</code></a></div>
+    <p class="what">
+      The <code>Protocol</code> trait, the effect vocabulary, <code>Cx</code>, time, storage and the
+      composition primitives. Everything else depends on this and it depends on nothing.
+    </p>
+  </li>
+  <li>
+    <div class="name"><a href="recon_sim/index.html"><code>recon_sim</code></a></div>
+    <p class="what">
+      The deterministic simulator. It <em>is</em> the fair-loss network, and it is the project's
+      standard of evidence — seeded, with a virtual clock, fault injection, and a trace that
+      properties are asserted over. A failing run is reproducible from its seed.
+    </p>
+  </li>
+  <li>
+    <div class="name"><a href="recon_protocols/index.html"><code>recon_protocols</code></a></div>
+    <p class="what">
+      The abstractions themselves — links, failure detectors, broadcasts, consensus — each
+      transcribed from Cachin, Guerraoui &amp; Rodrigues with the pseudocode quoted in the module
+      and every departure from the page stated beside it.
+    </p>
+  </li>
+</ul>
+
+<footer>
+  Built from <code>master</code> by <code>cargo doc</code>. The prose that these modules are written
+  against — on bounded space, on conditional guarantees, and the post-mortem that set the ordering —
+  lives in <a href="https://github.com/cmsd2/recon">the repository</a>.
+</footer>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,114 @@
+# The gate, and the published documentation.
+#
+# The build step is `./scripts/check.sh` and nothing that reimplements it. That script is the
+# definition of "clean" for this project — `CLAUDE.md` names it as the gate for every commit, and
+# `README.md`'s guard table describes its contents. A workflow listing `cargo fmt`, `cargo clippy`,
+# … separately would be a second definition that can disagree with the first, silently, in the
+# direction that matters: CI passing something a developer's run would have caught, or the reverse.
+# Running the script means the two are the same thing by construction, and adding a check to the
+# gate puts it in CI with no second edit here.
+#
+# It also reports more than a step-per-check workflow would. `check.sh` uses `set -uo pipefail`
+# *without* `-e`, so it runs every check after one fails and prints PASS/FAIL for each. One run
+# therefore names every problem, where separate steps would stop at the first.
+#
+# Nothing is installed that the runner does not already have: `ubuntu-latest` ships rustup with a
+# current stable toolchain including clippy and rustfmt, so the third-party actions here are
+# checkout and the cache, and no more. Every action in a workflow is someone else's code running
+# with a token, and that is worth minimising where it is cheap.
+
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+# Superseded runs on the same ref are pointless. The docs job overrides this — see there.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: check.sh
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      # Current stable rather than a pinned version. The trade is deliberate and recorded in the
+      # change's design: the code always builds on current stable, and in exchange a clippy or
+      # rustdoc release can turn a green commit red with no change to this repository. If that
+      # becomes tiresome, `rust-toolchain.toml` is the one-file fix.
+      - name: Use current stable
+        run: |
+          rustup update stable --no-self-update
+          rustup default stable
+          rustc --version && cargo clippy --version && cargo fmt --version
+
+      - uses: Swatinem/rust-cache@v2
+
+      # The gate. Correctness may not depend on the cache above: a cold one is slower and a stale
+      # one is a rebuild, never a different verdict.
+      - name: Run the gate
+        run: ./scripts/check.sh
+
+  docs:
+    name: API documentation
+    needs: check
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    # Scoped to this job, so the gate above keeps `contents: read` and nothing more.
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # The opposite of the gate's: cancelling a deployment part-way leaves a half-written site,
+    # where cancelling a superseded test run costs nothing.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use current stable
+        run: |
+          rustup update stable --no-self-update
+          rustup default stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      # `--no-deps` because the dependencies' documentation is already on docs.rs and building it
+      # is most of the time. Public items only: `--document-private-items` would expose a great
+      # deal of internal reasoning that the module documentation already summarises deliberately,
+      # and the summary is the better artifact.
+      #
+      # Warnings are denied by `check.sh`, which has already passed for this commit, so a broken
+      # intra-doc link cannot reach the published site.
+      - name: Build the documentation
+        run: cargo doc --workspace --no-deps
+
+      # `cargo doc` writes no landing page. Redirecting to one crate would be picking a favourite,
+      # and how the three relate is itself worth saying on the way in.
+      - name: Write the landing page
+        run: cp .github/pages/index.html target/doc/index.html
+
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/doc
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # recon
 
+[![CI](https://github.com/cmsd2/recon/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/cmsd2/recon/actions/workflows/ci.yml)
+[![API documentation](https://img.shields.io/badge/docs-API%20reference-blue)](https://cmsd2.github.io/recon/)
+
+The first badge is the whole gate, not the tests: it is red if *any* check is failing — clippy, the
+ordered-maps guard, the transport guard, the documentation guard — because "do not commit until
+these are clean" already treats them as one thing. The second is a link rather than a status, and
+stays blue whether or not the last deployment worked.
+
 Distributed message-passing algorithms — links, failure detection, broadcast, eventually consensus
 — written in Rust so that the code reads as the algorithm.
 
@@ -57,6 +65,10 @@ to a session ending — and shows the first leaving a correct process without th
 second cannot. It is the shortest path to seeing what the project is for.
 
 ## The crates
+
+The API documentation is published from `master`: **<https://cmsd2.github.io/recon/>**. Much of what
+is worth reading is in the module documentation — the quoted pseudocode, the departures from the
+page, and the space bound each module claims.
 
 | Crate | What it is |
 |---|---|
@@ -589,9 +601,13 @@ thinking without committing to anything. Project context and per-artifact rules 
 
 ### The gate
 
-`./scripts/check.sh` must pass in full before every commit. A pre-commit hook runs it. Do not
-commit with anything outstanding — warnings accumulate into noise, and noise is how a real
-diagnostic gets missed.
+`./scripts/check.sh` must pass in full before every commit. A pre-commit hook runs it, and CI runs
+the same script on `master` and on every pull request — so the two cannot disagree about what
+"clean" means. Do not commit with anything outstanding — warnings accumulate into noise, and noise
+is how a real diagnostic gets missed.
+
+It aggregates rather than stopping at the first failure, so one run tells you everything that is
+wrong rather than the first thing.
 
 ```bash
 cargo fmt --all                                        # rustfmt.toml is checked in
@@ -611,6 +627,11 @@ at runtime rather than loud — each one is a bug that would otherwise be found 
 | [`check-error-types.sh`](scripts/check-error-types.sh) | `io::Error` for domain failures, and the literal `"json decoding error"` | flattening distinct failures into one string makes them indistinguishable in a running cluster |
 | [`check-no-transport.sh`](scripts/check-no-transport.sh) | sockets, async runtimes, `.await` | constraint 1: algorithms before transport, and this is what keeps it honest |
 | `cargo clippy -D warnings` | any lint | warnings accumulate and hide real diagnostics |
+| `cargo doc -D warnings` | a broken intra-doc link | a docstring naming something that is not there asserts a contract the code does not have, and it fails silently — the link just renders as text. It had already happened four times when the check was added: `Cmd::Start` documented in two modules as the way to begin a broadcast after the command was removed, a deleted `ScopedLink` still explained, and a renamed method still linked |
+
+CI runs the whole of `./scripts/check.sh` on `master` and on every pull request targeting it — the
+script itself, not a reimplementation of it, so adding a guard here puts it in CI with no second
+edit. The badge at the top of this file reports all of it.
 
 `check-no-transport.sh` is meant to be **deleted deliberately**, in the commit that introduces
 transport under constraint 5. Do not weaken it; delete it, or leave it alone.

--- a/crates/recon-protocols/src/epoch_consensus.rs
+++ b/crates/recon-protocols/src/epoch_consensus.rs
@@ -67,8 +67,8 @@
 //! `upon event ⟨ ep, Abort ⟩ … halt;  // stop operating when aborted`. An instance that kept
 //! answering after being abandoned would be a second leader for its epoch under another name: it
 //! could still collect a quorum and decide, while the epoch that replaced it decided something
-//! else. [`EpochConsensus::aborted`] is checked at the top of every handler, and the suite delivers
-//! a message to an aborted instance and asserts that nothing at all comes out.
+//! else. The flag [`EpochConsensus::is_aborted`] reports is checked at the top of every handler, and
+//! the suite delivers a message to an aborted instance and asserts that nothing at all comes out.
 //!
 //! # Departure: directed replies travel by directed broadcast
 //!

--- a/crates/recon-protocols/src/flooding_consensus.rs
+++ b/crates/recon-protocols/src/flooding_consensus.rs
@@ -100,8 +100,10 @@
 //!   that round returns to it.
 //! - A second `Propose` from the same process is ignored. The book's model has one proposal per
 //!   process, and Module 5.1 provides one decision per instance.
-//! - `⟨c, Init⟩` is not a separate event. `new` establishes the state, and [`Cmd::Start`] begins
-//!   failure detection, without which no round can ever complete after a crash.
+//! - `⟨c, Init⟩` **is** a separate event: `new` establishes the state, and [`Protocol::on_init`]
+//!   starts the detector beneath, without which no round can ever complete after a crash. It was a
+//!   `Cmd::Start` before the trait had an init event, which is why the only request now is
+//!   [`Cmd::Propose`].
 
 use core::time::Duration;
 use recon_core::{Child, NodeId, ProtoCx, Protocol, TimerId};
@@ -191,7 +193,7 @@ pub struct FloodingConsensus<P: Clone + Ord, L: VolatileLink<Flood<P>> = Perfect
 impl<P: Clone + Ord, L: VolatileLink<Flood<P>>> FloodingConsensus<P, L> {
     /// Consensus among `members`, over a link the caller supplies.
     ///
-    /// The link is anything satisfying [`Link`]; this layer never names an implementation.
+    /// The link is anything satisfying [`crate::link::Link`]; this layer never names an implementation.
     pub fn with_link(
         me: NodeId,
         members: impl IntoIterator<Item = NodeId>,

--- a/crates/recon-protocols/src/link.rs
+++ b/crates/recon-protocols/src/link.rs
@@ -49,7 +49,7 @@ use recon_core::{NodeId, Protocol};
 ///
 /// `P` is the payload the layer above sends. A link is free to wrap it — the perfect link adds a
 /// message identifier — which is why [`Link::send`] builds the request rather than the layer above
-/// constructing one, and why [`Link::delivered`] takes the payload back out.
+/// constructing one, and why [`Link::classify`] takes the payload back out.
 ///
 /// Satisfying the port is a decision, not an accident of shape. An earlier draft made it a blanket
 /// impl over every `Protocol` with the right associated types, which meant a protocol became a link

--- a/crates/recon-protocols/src/perfect_failure_detector.rs
+++ b/crates/recon-protocols/src/perfect_failure_detector.rs
@@ -125,7 +125,10 @@ impl PerfectFailureDetector {
     ///
     /// For strong accuracy, `timeout` must exceed `period` plus the network's delivery bound —
     /// otherwise a live process's heartbeat can arrive after it has already been accused.
-    /// Configure the bound from [`recon_sim::Sim::delivery_bound`] rather than guessing it.
+    /// Configure the bound from the simulator's own `Sim::delivery_bound` rather than guessing
+    /// it. Named rather than linked: `recon-sim` is a dev-dependency of this crate, so the path
+    /// does not exist for a reader of these docs — and it is the right way round, since a protocol
+    /// that depended on the simulator would be the thing constraint 2 forbids.
     pub fn new(
         me: NodeId,
         peers: impl IntoIterator<Item = NodeId>,

--- a/crates/recon-protocols/src/perfect_link.rs
+++ b/crates/recon-protocols/src/perfect_link.rs
@@ -174,14 +174,21 @@ impl<P: Clone> Protocol for PerfectLink<P> {
     }
 }
 
-/// The perfect link satisfies the link port, and only its unscoped half.
+/// The perfect link satisfies the link port, and reports no scope boundary.
 ///
-/// It deliberately does not implement [`crate::link::ScopedLink`]: PL2's no-duplication holds
-/// within one incarnation of the recipient, and the link has no means of observing that
-/// incarnation ending. A link that reported a boundary it cannot see would be asserting something
-/// it does not know — which `docs/scope-annotated-modules.md` forbids by Definition 2a. A layer
-/// that needs to be told about a boundary therefore cannot be composed over this link, and the
-/// compiler says so.
+/// [`Link::classify`](crate::link::Link::classify) here never yields
+/// [`LinkInd::Boundary`](crate::link::LinkInd::Boundary): PL2's no-duplication holds within one
+/// incarnation of the recipient, and this link has no means of observing that incarnation ending. A
+/// link that reported a boundary it cannot see would be asserting something it does not know, which
+/// `docs/scope-annotated-modules.md` forbids by Definition 2a.
+///
+/// **Nothing in the type system enforces that**, and [`crate::link`] records why: a `ScopedLink`
+/// marker trait existed for exactly this and was deleted for want of a consumer — the one layer
+/// that should have bounded on it could not, because its resend lives in the `Link` impl and the
+/// tighter bound would have fallen on every link. What keeps it honest instead is the
+/// classification itself, and `tests/link_port.rs` pins both halves: that this link's
+/// classification never yields a boundary, and that the session link's yields one for each variant
+/// that reports it.
 impl<P> crate::link::Link<P> for PerfectLink<P>
 where
     P: Clone,

--- a/crates/recon-protocols/src/probabilistic_broadcast.rs
+++ b/crates/recon-protocols/src/probabilistic_broadcast.rs
@@ -171,8 +171,8 @@ impl Config {
 /// Gossip: relay to a random few, for a bounded number of rounds.
 ///
 /// `L` is the link beneath and it is a parameter, so this composes over a perfect link, a session
-/// link, or an application's own. It bounds on [`Link`] rather than anything narrower because
-/// gossip needs nothing of a scope boundary beyond passing it upward.
+/// link, or an application's own. It bounds on [`crate::link::Link`] rather than anything narrower
+/// because gossip needs nothing of a scope boundary beyond passing it upward.
 #[derive(Debug)]
 pub struct ProbabilisticBroadcast<P: Clone, L: VolatileLink<Carried<P>> = FairLossLink<Gossip<P>>> {
     me: NodeId,

--- a/crates/recon-protocols/src/uniform_reliable_broadcast.rs
+++ b/crates/recon-protocols/src/uniform_reliable_broadcast.rs
@@ -61,8 +61,9 @@
 //! - Two children both send, so this layer's wire type is an enum distinguishing a broadcast
 //!   payload from a heartbeat. It is the first multiplexing in the stack, and it is typed: a
 //!   mis-wiring is a compile error rather than a silently undelivered message.
-//! - `⟨urb, Init⟩` is not a separate event. `new` establishes the state, and [`Cmd::Start`] begins
-//!   failure detection.
+//! - `⟨urb, Init⟩` **is** a separate event: `new` establishes the state, and
+//!   [`Protocol::on_init`] starts the detector beneath. It was a `Cmd::Start` before the trait had
+//!   an init event, which is why the only request now is [`Cmd::Broadcast`].
 //! - Neither `ack` nor `pending` is garbage collected, as in the book. Long runs grow.
 //!
 //! # Over a link that reports scope boundaries

--- a/openspec/changes/ci-on-master-and-prs/.openspec.yaml
+++ b/openspec/changes/ci-on-master-and-prs/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-09-01
+skip_specs: true

--- a/openspec/changes/ci-on-master-and-prs/design.md
+++ b/openspec/changes/ci-on-master-and-prs/design.md
@@ -1,0 +1,184 @@
+## Context
+
+See `proposal.md` — Why. The constraint that shapes everything here is that `./scripts/check.sh`
+already exists and is already the definition of "clean": seven checks, aggregating rather than
+short-circuiting, exit 1 if any failed. CI's job is to run it, not to have an opinion about it.
+
+## Goals / Non-Goals
+
+Goals: the gate runs on `master` and on pull requests targeting it; a failure is legible without
+opening a log; the state of `master` is visible from the README; the API documentation is published
+and cannot rot unnoticed. Non-goals: a macOS runner, a pinned toolchain, release automation,
+coverage, benchmarks, and validating OpenSpec artifacts — each addressed below or in the open
+questions.
+
+## Decisions
+
+### CI runs `check.sh`, it does not reimplement it
+
+One step, `./scripts/check.sh`, rather than seven steps mirroring what the script does.
+
+The argument is drift. `CLAUDE.md` names that script as the gate for every commit and the README's
+guard table describes its contents; a workflow that lists `cargo fmt`, `cargo clippy`, … separately
+is a second definition of "clean" that can disagree with the first, silently, in the direction that
+matters — CI passing something a developer's run would have caught, or the reverse. Running the
+script means the two are the same thing by construction, and adding a guard to `check.sh` puts it in
+CI with no second edit.
+
+What it costs is granularity in the Actions UI: one red step rather than a red `clippy` step. That
+is smaller than it looks, because the script prints `PASS:`/`FAIL:` per section and — since it uses
+`set -uo pipefail` without `-e` — **runs every check even after one fails**. A single CI run
+therefore reports every problem at once, which a step-per-check workflow would not: that stops at
+the first failure.
+
+*Alternative — steps per check, sharing a composite action.* Removes the drift but adds a layer to
+keep in step with the script, which is the same problem one level down.
+
+### Nothing is installed that the runner does not already have
+
+`ubuntu-latest` ships rustup with a current stable toolchain including `clippy` and `rustfmt`, so the
+job needs `rustup update stable` and nothing else. Third-party actions are then limited to caching.
+
+That matters here for the ordinary reason — every action in a workflow is code from someone else
+running with a token — and it is worth taking cheaply where it is cheap. `actions/checkout` is
+unavoidable. A toolchain action is not.
+
+### Caching, and what it is allowed to affect
+
+`Swatinem/rust-cache` over the cargo registry and `target/`, keyed on the lockfile and the compiler
+version. Correctness may not depend on it: a cold cache produces the same result more slowly, and a
+poisoned or stale one is a *rebuild*, never a different verdict — `cargo` decides that, not the
+cache key.
+
+Worth watching rather than assuming: this workspace builds `--all-targets` across thirty-odd test
+binaries, so `target/` is large and may approach the per-repository cache limit. If it does, the
+answer is to cache the registry only, which keeps most of the win.
+
+*Alternative — `actions/cache` by hand.* One fewer third-party action, and a cache key for a Rust
+build that is right in all the cases `rust-cache` already handles is more subtle than it looks.
+
+### Documenting is a second job, and it publishes nothing from a red build
+
+`needs: check`, `if: github.ref == 'refs/heads/master'`. A pull request builds no documentation and
+deploys none; `master` deploys only what a passing gate produced. The alternative — deploying in
+parallel with the checks — publishes documentation for a commit that does not compile, which is
+worse than publishing nothing.
+
+`cargo doc --workspace --no-deps`: `--no-deps` because the dependencies' documentation is already on
+docs.rs and building it is most of the time; `--workspace` because all three crates are the subject.
+Public items only — `--document-private-items` would expose a great deal of internal reasoning that
+the module documentation already summarises deliberately, and the summary is the better artifact.
+
+`cargo doc` writes no landing page, so the job adds a small hand-written `index.html` listing the
+three crates. Redirecting to one of them would be picking a favourite, and the crates' relationship —
+core, then the simulator, then the protocols — is itself worth stating on the way in.
+
+### The Pages deployment, and what it needs that this change cannot provide
+
+`actions/upload-pages-artifact` and `actions/deploy-pages`, with `pages: write` and `id-token: write`
+scoped to the deploy job alone rather than the workflow. That keeps the gate job on `contents: read`,
+which is the whole of what it needs.
+
+**It requires Settings → Pages → Source set to "GitHub Actions", once, by hand.** Nothing in a
+repository can set that, so the first `master` run after this lands will fail its deploy job until
+somebody does. Stated here rather than discovered.
+
+Pages deployments take `concurrency: group: pages, cancel-in-progress: false` — the opposite of the
+gate's — because cancelling a deployment part-way is how a site ends up half-written, where
+cancelling a superseded test run costs nothing.
+
+*Alternative — pushing to a `gh-pages` branch.* Works with the older Pages setting and needs no
+manual change, at the cost of a third-party action holding write access to the repository and a
+branch of generated HTML living beside the source. The design's preference for few third-party
+actions applies most where the action is most privileged.
+
+### Broken documentation links are a gate, and gates live in `check.sh`
+
+This follows from the first decision rather than being a separate opinion. `cargo doc` with
+`RUSTDOCFLAGS=-D warnings` is a lint; the workflow runs `check.sh` and nothing else; therefore the
+lint goes in `check.sh` and CI acquires it for free. A developer also sees it before pushing, which
+is where a broken link is cheapest to fix.
+
+It earns its place rather than being tidiness. Running it now fails, and four of the eight
+complaints are stale prose: `Cmd::Start` is documented in two modules as the way to begin something
+that no longer has it, `ScopedLink` was deleted in `link-parameterisation` while `perfect_link` still
+explains its relationship to it, and `Link::delivered` was renamed `classify`. `CLAUDE.md` treats a
+stale docstring as a defect — "a stale quote asserts an algorithm the code deliberately does not
+implement" — and this is the mechanical check for the class.
+
+The eight are not one problem. Two are removed items, one is a rename, one is a deleted type, three
+are unresolved paths, and one is public documentation pointing at a private field. Each needs reading
+rather than a bulk edit, and the fix for a stale reference is to correct the *prose*, not to delete
+the link and leave a sentence about something that is not there.
+
+### Concurrency, permissions, and a timeout
+
+Superseded runs on the same ref are cancelled, so pushing twice to a PR does not pay for both.
+`permissions: contents: read` — the job reads the repository and needs nothing else, and the default
+token grants more than that. A job timeout, because the suite is seconds and a job running for hours
+is a hung runner rather than a slow test.
+
+### Two badges, and they say different kinds of thing
+
+The **gate** badge is the workflow's own, so it is green when *every* check passes and red when any
+fails — clippy, the ordered-maps guard, the transport guard, as much as the tests. That is the right
+granularity: "do not commit until these are clean" already treats them as one thing, and a badge
+reporting only `cargo test` would sit green while the determinism guard was failing. It tracks
+`master`, which is what a badge should mean.
+
+The **documentation** badge is not a status at all — it is a link wearing the same clothes, so that
+the two sit together and the way into the published API reference is the first thing on the page.
+Worth being honest about in the workflow's comment and in the README's own words: a static
+`docs`/`pages` badge is green whether or not the last deployment succeeded, so it must not be read as
+one. If that matters later, the deploy workflow has a status badge of its own that could sit beside
+it — but two badges either side of one link is more clutter than the question deserves today.
+
+## Risks / Trade-offs
+
+- **Without a pinned toolchain, a clippy release can turn `master` red with no change to the
+  repository.** `-D warnings` is a hard gate, so this will happen eventually rather than might. →
+  Accepted deliberately; the cost is a lint fix on a day nobody chose, and the alternative constrains
+  every local build. `rust-toolchain.toml` is the fix if it becomes annoying, and it is one file.
+- **Ubuntu only leaves determinism across platforms an untested claim** — `simulation`'s spec
+  requires that a run is fully determined by its seed, and that is still evidence from one machine.
+  → Recorded, not fixed. A macOS entry in a matrix is a three-line change when it is wanted.
+- **A green badge will mean less than it appears to** until the workflow has actually failed once.
+  → The first PR that breaks something is the check, and it is worth deliberately breaking one to
+  confirm the gate catches it rather than assuming a workflow that has only ever passed is working.
+- **Denying doc warnings makes a compiler upgrade able to break the build**, since rustdoc gains
+  lints as rustc does, and nothing here is pinned. → The same trade already accepted for
+  `clippy -D warnings`, and accepted for the same reason: a lint that only warns is a lint nobody
+  acts on. This repository already runs three custom guards on that principle.
+- **The deploy job will fail until Pages is switched to "GitHub Actions".** → It cannot be avoided
+  from inside the repository. It is named in the proposal, in this design and in the tasks, and it
+  does not affect the gate.
+
+## Migration Plan
+
+1. The eight documentation defects, then `cargo doc` with warnings denied added to `check.sh`. This
+   comes first: adding the guard before the fixes leaves the gate red, and the fixes are worth
+   reading individually.
+2. The workflow's gate job, and a deliberate red run to prove it fails when it should.
+3. The documentation job, once Pages is switched over.
+4. The badge and the README.
+
+Additive throughout: no crate, dependency, or local build is touched, and deleting the workflow file
+returns the repository to where it is now.
+
+## Open Questions
+
+- **A macOS runner**, whose value is not redundancy but the first evidence that a seeded run replays
+  identically on another platform and architecture. That is a claim in `openspec/specs/simulation`,
+  and it would be checked rather than asserted for the cost of doubling the runs.
+- **Validating the OpenSpec artifacts in CI** — `openspec validate --specs --strict` would catch a
+  malformed spec on the pull request that introduced it, rather than at archive time. It needs Node
+  on the runner, which is why it is not here; archive already runs it, so the gap is only the window
+  between writing a spec and archiving its change.
+- **`cargo build --locked`**, so a pull request cannot quietly move `Cargo.lock`. It belongs in
+  `check.sh` rather than in the workflow, by the first decision above, so it is a change to the gate
+  rather than to CI.
+- **Whether the published documentation should carry the `docs/` essays** — `bounded-space.md`,
+  `conditional-guarantees.md`, `scope-annotated-modules.md` — beside the API reference. They are the
+  argument the modules are written against, and a reader arriving at `epoch_consensus` from a search
+  engine has no path to them. That is a site rather than a `cargo doc` output, and a separate
+  question.

--- a/openspec/changes/ci-on-master-and-prs/proposal.md
+++ b/openspec/changes/ci-on-master-and-prs/proposal.md
@@ -1,0 +1,81 @@
+## Why
+
+`./scripts/check.sh` is the gate for every commit — `CLAUDE.md` says so, and it must pass in full
+before anything lands. Nothing enforces that. It runs when a developer remembers to run it, on
+whatever compiler that developer happens to have, and on one machine. There is no CI at all:
+`.github/` holds prompts and skills and no workflows.
+
+Three consequences, and they are not hypothetical for this repository in particular:
+
+- **A guard that is skipped is a guard that does not exist.** Three of the checks are shell
+  scripts encoding failure modes that are silent at runtime — `HashMap` iteration order breaking
+  seed reproducibility, `io::Error` flattening distinct failures, a socket appearing before
+  constraint 5 discharges it. They are mechanical checks precisely because review misses them, and
+  they only run if something runs them.
+- **A pull request has nothing to say about itself.** There is no signal on a branch other than a
+  developer's word that they ran the script.
+- **The whole project rests on determinism, and it has only ever been observed on one machine.**
+  `openspec/specs/simulation/spec.md` requires that a run is fully determined by its seed and
+  configuration. Every measurement in `docs/bounded-space.md` and every seeded property test assumes
+  it. That assumption has been checked on exactly one platform, by one person.
+
+## What Changes
+
+- **A GitHub Actions workflow** that runs on pushes to `master` and on pull requests targeting it,
+  and whose single job runs `./scripts/check.sh` — the same script, not a reimplementation of it.
+- **The build is cached** on the cargo registry and the `target` directory, keyed on `Cargo.lock`.
+- **The README's guard table says what enforces it**, since the table currently describes checks
+  that run only by hand.
+- **Two badges at the top of the README.** One reports the gate — and since it is the workflow's own
+  badge rather than a test-only one, red means *any* check is failing, which is what "do not commit
+  until these are clean" already treats them as. The other links to the published documentation, so
+  the way in is the first thing on the page rather than something to go looking for.
+- **The API documentation is built and published to GitHub Pages** from `master` only, and only
+  after the gate has passed. Much of this repository's value is in its module documentation — the
+  quoted pseudocode, the departures, the space bounds — and it is currently readable only by
+  cloning.
+- **Broken documentation links become a guard.** `cargo doc` does not currently build clean, and
+  what it is complaining about is not cosmetic:
+
+  | | |
+  |---|---|
+  | `Cmd::Start` in `flooding_consensus` and `uniform_reliable_broadcast` | a command that **no longer exists**, still documented as the way to begin |
+  | `crate::link::ScopedLink` in `perfect_link` | deleted in `link-parameterisation`; `link.rs` records at length that it was, and this module still says it deliberately does not implement it |
+  | `Link::delivered` in `link.rs` | renamed to `classify` |
+  | `Link` ×2, `recon_sim::Sim::delivery_bound`, a public link to a private field | paths that do not resolve |
+
+  Four of the eight are stale prose asserting things that are not there — the failure `CLAUDE.md`
+  calls out by name, since "this repository's method is reading code against its quoted contract".
+  They are fixed here, and `cargo doc` with warnings denied joins `check.sh` so that the next one
+  cannot land. It goes in the script rather than the workflow for the reason the design gives: a
+  gate belongs where every gate is, and CI then picks it up without a second edit.
+
+Publishing needs one thing this change cannot do for itself: **Settings → Pages → Source must be set
+to "GitHub Actions"**, once, by hand. Until it is, the deploy job fails and the gate is unaffected.
+
+Two decisions taken deliberately, both narrowing scope:
+
+- **Ubuntu only.** A macOS runner would be the first evidence that determinism survives a change of
+  platform and architecture — dev is macOS on arm64 — but that doubles the cost of every run, and
+  the claim is recorded as untested rather than tested. Noted in `design.md` as the obvious
+  extension.
+- **No toolchain pin.** CI uses current stable and so does a developer's machine, which means a new
+  clippy release can turn a green commit red with no change to the repository. `-D warnings` is a
+  hard gate, so that will happen eventually; the trade is that the code always builds on current
+  stable and no file constrains local development.
+
+## Capabilities
+
+None. `skip_specs: true` is set in this change's `.openspec.yaml`, which is the honest marker
+rather than a convenience: a workflow that runs an existing script changes no behaviour of the
+system this repository specifies. The capabilities here are `protocol-core`, `simulation`, `links`,
+`broadcast`, `consensus` and `failure-detection` — what the protocols must do — and CI is the
+machinery that runs their checks rather than a claim about what they check. Inventing a capability
+to satisfy the schema would be writing a specification for a build script.
+
+## Impact
+
+One new file, `.github/workflows/ci.yml`. `scripts/check.sh` gains a check, and eight docstrings
+across `recon-protocols` are corrected. `README.md` is dated in four places: its guard table, its
+build instructions, its head, which gains the badge, and wherever it can now point at published
+documentation. No crate's behaviour changes and no dependency moves. No crate changes, no dependency changes, and nothing that alters a local build.

--- a/openspec/changes/ci-on-master-and-prs/tasks.md
+++ b/openspec/changes/ci-on-master-and-prs/tasks.md
@@ -1,0 +1,88 @@
+## 1. The documentation defects, and then the guard
+
+The fixes come before the guard: adding it first leaves the gate red, and each of these wants
+reading rather than a bulk edit. The fix for a stale reference is to correct the **prose** — a
+sentence explaining this module's relationship to something that no longer exists is still wrong
+once the link is deleted.
+
+- [x] 1.1 `Cmd::Start` in `flooding_consensus` and `uniform_reliable_broadcast`: the command was
+      removed, and both modules still document it as the way to begin. Establish what begins them
+      now and say that instead
+- [x] 1.2 `crate::link::ScopedLink` in `perfect_link`: the type was deleted in
+      `link-parameterisation`, and `link.rs` records at length why. `perfect_link` still explains
+      that it deliberately does not implement it — rewrite the paragraph against what is there
+- [x] 1.3 `Link::delivered` in `link.rs`: renamed to `classify`
+- [x] 1.4 `Link` in `flooding_consensus` and `probabilistic_broadcast`: unresolved paths, not stale
+      claims — point them at `crate::link::Link`
+- [x] 1.5 `recon_sim::Sim::delivery_bound` in `perfect_failure_detector`: `recon-protocols` does not
+      depend on `recon-sim` outside dev-dependencies, so rustdoc cannot resolve it. Name it in prose
+      rather than linking across a dependency that is not there
+- [x] 1.6 `epoch_consensus`'s public documentation links to the private `EpochConsensus::aborted`.
+      Decide whether the field should be readable or the sentence should not name it. **Neither was
+      needed**: `is_aborted` already exists as the public accessor, so the sentence names that
+- [x] 1.7 Add `cargo doc --workspace --no-deps` with `RUSTDOCFLAGS=-D warnings` to `check.sh`, with
+      a comment saying what class of defect it catches — the same shape as the three guards already
+      there. Verify it fails before 1.1–1.6 and passes after. Confirmed by reintroducing one stale
+      link: exit 101 with it, 0 without
+
+## 2. The gate on master and pull requests
+
+- [x] 2.1 Add `.github/workflows/ci.yml`: on pushes to `master` and pull requests targeting it, one
+      job on `ubuntu-latest` whose build step is `./scripts/check.sh` and nothing that reimplements
+      it
+- [x] 2.2 `rustup update stable` rather than a toolchain action — the runner already ships rustup,
+      clippy and rustfmt, so the only third-party actions are checkout and the cache
+- [x] 2.3 Cache the cargo registry and `target/` with `Swatinem/rust-cache`, and check what it
+      actually costs: this workspace builds `--all-targets` across thirty-odd test binaries. If
+      `target/` approaches the per-repository limit, cache the registry only and say so in the file.
+      Left to `Swatinem/rust-cache`'s own defaults, which already exclude the build artefacts of the
+      workspace's own crates; the size is worth watching on the first few runs rather than guessing
+- [x] 2.4 `concurrency` cancelling superseded runs on the same ref, `permissions: contents: read`,
+      and a job timeout
+- [x] 2.5 Comment the workflow with *why* it runs the script rather than the checks — the next
+      person to add a step is the one who needs to read it
+
+## 3. Prove the gate fails
+
+- [ ] 3.1 Open a pull request that deliberately breaks one check — a formatting violation is the
+      cheapest — and confirm CI goes red and the log names which check failed
+- [ ] 3.2 Confirm a run reports **every** failing check rather than stopping at the first: break two
+      at once and read the summary. `check.sh` aggregates by design, and a workflow that lost that
+      would be worse than the script it replaces
+- [ ] 3.3 Confirm the gate badge goes red, and green again when the branch is fixed. A badge that
+      has only ever been green is a badge nobody has tested
+
+## 4. Publishing the documentation
+
+- [ ] 4.1 **Set Settings → Pages → Source to "GitHub Actions".** Manual, once, and nothing in the
+      repository can do it — the deploy job fails until it is done
+- [x] 4.2 A second job, `needs` the gate and `if: github.ref == 'refs/heads/master'`, building
+      `cargo doc --workspace --no-deps`. A pull request builds no documentation and deploys none
+- [x] 4.3 Write the landing page `cargo doc` does not: a small `index.html` naming the three crates
+      and how they relate — core, then the simulator, then the protocols — rather than redirecting
+      to whichever one seems most important. Lives in `.github/pages/`, not `docs/`: that directory
+      holds the project's essays and has a row per file in the README's documentation table, and a
+      piece of site scaffolding is not one of them
+- [x] 4.4 `actions/upload-pages-artifact` and `actions/deploy-pages`, with `pages: write` and
+      `id-token: write` on this job **only**, so the gate job keeps `contents: read`
+- [x] 4.5 `concurrency: group: pages, cancel-in-progress: false` — the opposite of the gate's,
+      because cancelling a deployment part-way leaves a half-written site where cancelling a
+      superseded test run costs nothing
+- [ ] 4.6 Verify the published site: the three crates reachable from the landing page, a module's
+      quoted pseudocode rendering as intended, and the intra-doc links resolving now that 1.1–1.6
+      are fixed
+
+## 5. What this dates
+
+- [x] 5.1 Two badges at the head of `README.md`: the workflow's own for the gate, and a link to the
+      published documentation. Say in the surrounding text that the second is a link rather than a
+      status, so a reader does not take a green `docs` badge as evidence the last deploy worked
+- [x] 5.2 The guard table: it describes checks and says nothing about what runs them. Add the
+      documentation guard as a row, say that CI runs the whole gate on `master` and on every pull
+      request, and that the badge reports all of it rather than the tests alone
+- [x] 5.3 The build instructions, which present `./scripts/check.sh` as something to remember to run
+- [x] 5.4 Point at the published API documentation where the README introduces the crates, since
+      that is where a reader wanting it will be
+- [ ] 5.5 `./scripts/check.sh` passes locally — including its new check — and the workflow passes on
+      a pull request. The two being the same run is the point of the change.
+      **Local half done**: all eight checks pass. The CI half needs the workflow on GitHub

--- a/openspec/changes/ci-on-master-and-prs/tasks.md
+++ b/openspec/changes/ci-on-master-and-prs/tasks.md
@@ -54,7 +54,7 @@ once the link is deleted.
 
 ## 4. Publishing the documentation
 
-- [ ] 4.1 **Set Settings → Pages → Source to "GitHub Actions".** Manual, once, and nothing in the
+- [x] 4.1 **Set Settings → Pages → Source to "GitHub Actions".** Manual, once, and nothing in the
       repository can do it — the deploy job fails until it is done
 - [x] 4.2 A second job, `needs` the gate and `if: github.ref == 'refs/heads/master'`, building
       `cargo doc --workspace --no-deps`. A pull request builds no documentation and deploys none

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -24,10 +24,23 @@ clippy() { cargo clippy --workspace --all-targets -- -D warnings; }
 build() { cargo build --workspace --all-targets; }
 tests() { cargo test --workspace; }
 
+# Documentation guard.
+#
+# A broken intra-doc link is a docstring naming something that is not there, and this project's
+# method is reading code against its quoted contract — so a stale reference asserts a contract the
+# code does not have. It is silent: nothing fails, the link just renders as text.
+#
+# It had already happened when this check was added. `Cmd::Start` was documented in two modules as
+# the way to begin a broadcast after the command had been removed; `perfect_link` still explained
+# its relationship to a `ScopedLink` trait deleted a change earlier; `Link::delivered` had been
+# renamed `classify`. Eight complaints in all, four of them stale prose.
+docs() { RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --quiet; }
+
 run "cargo fmt --check"  fmt
 run "cargo clippy -D warnings" clippy
 run "cargo build" build
 run "cargo test" tests
+run "cargo doc -D warnings" docs
 run "ordered maps" ./scripts/check-ordered-maps.sh
 run "error types"  ./scripts/check-error-types.sh
 run "no transport" ./scripts/check-no-transport.sh


### PR DESCRIPTION
Runs `./scripts/check.sh` on `master` and on pull requests, publishes the API documentation to Pages from `master`, and adds a guard for the documentation rot that writing this uncovered.

## The gate

The build step is the script and nothing that reimplements it. A workflow listing `fmt`, `clippy` and the rest separately would be a second definition of "clean", able to disagree with the first in the direction that matters. It also reports more: `check.sh` uses `set -uo pipefail` *without* `-e`, so one run names every failing check rather than stopping at the first.

Nothing is installed that `ubuntu-latest` does not already ship, so the third-party actions are checkout and the cache.

## Documentation rot

`cargo doc` did not build clean, and four of the eight complaints were stale prose rather than broken paths:

- **`Cmd::Start`** — documented in two modules as the way to begin a broadcast, after the command was removed. The prose was wrong twice over: `⟨Init⟩` *is* a separate event now, and both protocols start their detector in `on_init`.
- **`ScopedLink`** — deleted in `link-parameterisation`; `perfect_link` still explained its relationship to it, ending "and the compiler says so" when there is no longer a bound to say it.
- **`Link::delivered`** — renamed `classify`.

That is the failure `CLAUDE.md` names by name, and there was no guard for the class. There is now: `cargo doc` with warnings denied joins `check.sh`, which is where a gate belongs by the same argument as above, so CI acquires it with no second edit. Verified by reintroducing one stale link — exit 101 with it, 0 without.

The eight fixes were read individually rather than bulk-edited: the repair for a stale reference is to correct the prose, since a sentence explaining a relationship to something that is not there is still wrong once the link is deleted.

## Documentation publishing

A second job, `needs: check` and `master` only, so nothing is published from a red build and a pull request deploys nothing. Pages permissions are scoped to that job, leaving the gate on `contents: read`.

## Notes

- No toolchain pin: the code always builds on current stable, and in exchange a clippy or rustdoc release can turn a green commit red with no change here. Deliberate; `rust-toolchain.toml` is the one-file fix if it becomes tiresome.
- Ubuntu only. A macOS runner would be the first evidence that a seeded run replays identically on another platform — a claim `openspec/specs/simulation` makes and nothing has checked — but it doubles every run. Recorded as untested rather than tested.
- The docs badge is a link wearing badge clothes, and the README says so: it stays blue whether or not the last deployment worked.

This PR is itself the test of the gate — see the deliberate-failure commits and their reverts.